### PR TITLE
fix: explicit UTF-8 encoding for startup-critical file reads (CJK-locale Windows)

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -39,7 +39,7 @@ log = logging.getLogger("nelson.main")
 _version = "?"
 try:
     _vf = os.path.join(os.path.dirname(__file__), "version.py")
-    with open(_vf) as _f:
+    with open(_vf, encoding="utf-8") as _f:
         for _line in _f:
             if _line.startswith("EXTENSION_VERSION"):
                 _version = _line.split("=", 1)[1].strip().strip("\"'")
@@ -49,7 +49,7 @@ except Exception:
 _build_id = "dev"
 try:
     _bid_path = os.path.join(os.path.dirname(__file__), "_build_id.py")
-    with open(_bid_path) as _bf:
+    with open(_bid_path, encoding="utf-8") as _bf:
         for _bl in _bf:
             if _bl.startswith("BUILD_ID"):
                 _build_id = _bl.split("=", 1)[1].strip().strip("\"'")
@@ -154,7 +154,7 @@ def _fallback_discover_modules():
             continue
         try:
             import yaml
-            with open(yaml_path) as f:
+            with open(yaml_path, encoding="utf-8") as f:
                 manifest = yaml.safe_load(f)
             manifest.setdefault("name", entry)
             result.append(manifest)

--- a/plugin/options_handler.py
+++ b/plugin/options_handler.py
@@ -302,7 +302,7 @@ class _BrowseListener(unohelper.Base, XActionListener):
 # Layout constants — single source of truth in plugin/_layout.py
 # Loaded via exec() because UNO's import system can't resolve plugin._layout
 _layout_ns = {}
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '_layout.py')) as _f:
+with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '_layout.py'), encoding='utf-8') as _f:
     exec(_f.read(), _layout_ns)
 _PAGE_WIDTH = _layout_ns['PAGE_WIDTH']
 _PAGE_HEIGHT = _layout_ns['PAGE_HEIGHT']


### PR DESCRIPTION
Fixes #16.

On Windows, `open()` without `encoding=` follows the system ANSI code page. On CJK-locale systems (zh-CN cp936/GBK, ja-JP cp932, ko-KR cp949), importing `options_handler.py` crashes with `UnicodeDecodeError` while it reads `_layout.py` (which contains UTF-8 bytes — the `—` at offset 174). That import happens inside `pythonloader.writeRegistryInfo` during extension registration, so registration aborts before `Jobs.xcu` — the extension looks installed but the MCP server never starts. Full analysis in the linked issue.

Four one-line changes, all startup-critical reads:

- `plugin/options_handler.py` — the `_layout.py` exec-read (the registration blocker)
- `plugin/main.py` — the `version.py`, `_build_id.py`, and `module.yaml` reads (pure ASCII today, one non-ASCII byte away from the same crash)

**Tested** on the affected machine (Windows 11 zh-CN / GBK ANSI code page, LibreOffice 26.2.4.2): with exactly these changes applied to the 0.8.2 oxt, `unopkg add` completes without error, `unopkg list` shows every component registered including `Jobs.xcu`, and the server starts and answers `ping` / `tools/list` / `tools/call` against a live Calc document. (`PYTHONUTF8=1` is not an alternative — LibreOffice's embedded interpreter ignores it.)

Scope note: this deliberately touches only the reads that block registration/startup. There are more unencoded `open()` calls in `plugin/` (mostly config writes); happy to follow up with a repo-wide sweep if you want one.
